### PR TITLE
Add pip support

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+include src/mousetrap/mousetrap.yaml
+recursive-include src/mousetrap/locale *
+recursive-include src/mousetrap/haars *
+recursive-exclude * __pycache__
+recursive-exclude * *.py[co]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,4 +3,3 @@ recursive-include src/mousetrap/locale *
 recursive-include src/mousetrap/haars *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
-recursive-exclude * *.mo

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,3 +3,4 @@ recursive-include src/mousetrap/locale *
 recursive-include src/mousetrap/haars *
 recursive-exclude * __pycache__
 recursive-exclude * *.py[co]
+recursive-exclude * *.mo

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 from setuptools import setup, find_packages
 from setuptools.command.egg_info import egg_info
 from setuptools.command.install import install
+import glob
 import os
 import sys
 
@@ -12,6 +13,8 @@ sys.path.append(SRC_PATH)
 from mousetrap import __version__
 
 PYTHON_VERSION = sys.version_info
+
+LOCALE_PATH = "src/mousetrap/locale"
 
 all_requirements = [
     "pygobject",
@@ -93,6 +96,16 @@ On yum-based systems:
 
 The installation not work as expected without this dependency.
 """)
+
+        if not "install" in self.distribution.script_args:
+            sys.stdout.write("Removing generated locale files...\n")
+
+            compiled_files = glob.glob(LOCALE_PATH + "/**/LC_MESSAGES/*.mo")
+
+            for file_name in compiled_files:
+                sys.stdout.write("Removing compiled locale %s\n" % file_name)
+
+                os.remove(file_name)
 
         egg_info.run(self)
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,6 @@
 from setuptools import setup, find_packages
+from setuptools.command.egg_info import egg_info
+from setuptools.command.install import install
 import os
 import sys
 
@@ -29,6 +31,78 @@ if PYTHON_VERSION[0] > 2:
 else:
     requirements = python2_requirements
 
+
+class EggInfoCommand(egg_info):
+
+    def run(self):
+        try:
+            import gi.repository
+        except ImportError:
+            sys.stderr.write(
+"""
+PyGObject does not appear to be installed.  This cannot be installed
+automatically and must be installed to the system using your package manager.
+
+On apt-based systems:
+
+    sudo apt-get install python-gobject
+
+On yum-based systems:
+
+    sudo yum install python-gobject
+
+The installation not work as expected without this dependency.
+""")
+
+        try:
+            import Xlib
+        except ImportError:
+            sys.stderr.write(
+"""
+Python Xlib does not appear to be installed.  This cannot be installed
+automatically and must be installed to the system using your package manager.
+
+On apt-based systems:
+
+    sudo apt-get install python-xlib
+
+On yum-based systems:
+
+    sudo yum install python-xlib
+
+The installation not work as expected without this dependency.
+""")
+
+        try:
+            import cv2
+        except ImportError:
+            sys.stderr.write(
+"""
+OpenCV does not appear to be installed.  This cannot be installed
+automatically and must be installed to the system using your package manager.
+
+On apt-based systems:
+
+    sudo apt-get install python-opencv
+
+On yum-based systems:
+
+    sudo yum install python-opencv
+
+The installation not work as expected without this dependency.
+""")
+
+        egg_info.run(self)
+
+
+class InstallCommand(install):
+
+    def run(self):
+        print "Compiling language files..."
+
+        install.run(self)
+
+
 setup(
     name="mousetrap",
     version=__version__,
@@ -37,6 +111,10 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     packages=find_packages("src"),
+    cmdclass={
+        "egg_info": EggInfoCommand,
+        "install": InstallCommand,
+    },
     package_dir={
         "": "src",
     },

--- a/setup.py
+++ b/setup.py
@@ -57,21 +57,23 @@ The installation not work as expected without this dependency.
         try:
             import Xlib
         except ImportError:
-            sys.stderr.write(
-"""
-Python Xlib does not appear to be installed.  This cannot be installed
-automatically and must be installed to the system using your package manager.
+            # Python3-xlib can be installed automatically
+            if PYTHON_VERSION[0] < 3:
+                sys.stderr.write(
+    """
+    Python Xlib does not appear to be installed.  This cannot be installed
+    automatically and must be installed to the system using your package manager.
 
-On apt-based systems:
+    On apt-based systems:
 
-    sudo apt-get install python-xlib
+        sudo apt-get install python-xlib
 
-On yum-based systems:
+    On yum-based systems:
 
-    sudo yum install python-xlib
+        sudo yum install python-xlib
 
-The installation not work as expected without this dependency.
-""")
+    The installation not work as expected without this dependency.
+    """)
 
         try:
             import cv2

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,48 @@
+from setuptools import setup, find_packages
+import os
+import sys
+
+
+SRC_PATH = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "src"))
+
+sys.path.append(SRC_PATH)
+
+from mousetrap import __version__
+
+PYTHON_VERSION = sys.version_info
+
+all_requirements = [
+    "pygobject",
+    "pyyaml",
+]
+
+python2_requirements = all_requirements + [
+    "python-xlib",
+]
+
+python3_requirements = all_requirements + [
+    "python3-xlib",
+]
+
+if PYTHON_VERSION[0] > 2:
+    requirements = python3_requirements
+else:
+    requirements = python2_requirements
+
+setup(
+    name="mousetrap",
+    version=__version__,
+    url="https://wiki.gnome.org/Projects/MouseTrap",
+    license="GPL",
+    include_package_data=True,
+    install_requires=requirements,
+    packages=find_packages("src"),
+    package_dir={
+        "": "src",
+    },
+    entry_points={
+        "console_scripts": [
+            "mousetrap = mousetrap.main:main",
+        ],
+    },
+)

--- a/setup.py
+++ b/setup.py
@@ -45,4 +45,10 @@ setup(
             "mousetrap = mousetrap.main:main",
         ],
     },
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
+        "Programming Language :: Python :: 2",
+        "Programming Language :: Python :: 2.7",
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -98,7 +98,37 @@ The installation not work as expected without this dependency.
 class InstallCommand(install):
 
     def run(self):
-        print "Compiling language files..."
+        from subprocess import Popen
+
+        sys.stdout.write("Compiling locale files...\n")
+
+        program = "msgfmt"
+
+        LOCALE_PATH = "src/mousetrap/locale"
+
+        root, directories, files = os.walk(LOCALE_PATH).next()
+
+        language_codes = directories
+
+        for language_code in language_codes:
+            message_file = os.path.join(LOCALE_PATH, language_code, "LC_MESSAGES", "mousetrap.po")
+            compiled_file = os.path.join(LOCALE_PATH, language_code, "LC_MESSAGES", "mousetrap.mo")
+
+            arguments = [message_file, "--output-file", compiled_file]
+
+            sys.stdout.write("Compiling %s locale" % language_code)
+
+            command = [program] + arguments
+
+            process = Popen(command)
+
+            output, errors = process.communicate()
+            status_code = process.returncode
+
+            if status_code == 0:
+                sys.stdout.write(" [OK]\n")
+            else:
+                sys.stdout.write(" [FAIL]\n")
 
         install.run(self)
 

--- a/src/mousetrap/__init__.py
+++ b/src/mousetrap/__init__.py
@@ -1,0 +1,3 @@
+__version__ = "1.0.0a"
+
+VERSION = __version__.split(".")

--- a/src/mousetrap/i18n.py
+++ b/src/mousetrap/i18n.py
@@ -2,7 +2,7 @@ import gettext
 import locale
 import os
 
-LOCALE_DIR = os.path.join(os.path.dirname(__file__), "locale")
+LOCALE_DIR = os.path.abspath(os.path.join(os.path.dirname(os.path.realpath(__file__)), "locale"))
 
 translations = gettext.translation("mousetrap", localedir=LOCALE_DIR)
 

--- a/src/mousetrap/main.py
+++ b/src/mousetrap/main.py
@@ -106,5 +106,9 @@ class Loop(Observable):
         return CONTINUE
 
 
-if __name__ == '__main__':
+def main():
     App(CONFIG).run()
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This will allow MouseTrap to be installed using pip/setuptools to allow for easier distribution alongside the OS-based distribution.
